### PR TITLE
v0.3.1.0 - Fix commands action becoming invalid after re-opening settings window

### DIFF
--- a/gg.dennis.firebot.sdPlugin/manifest.json
+++ b/gg.dennis.firebot.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
 	"Name": "Firebot",
-	"Version": "0.3.0.0",
+	"Version": "0.3.1.0",
 	"Author": "DennisOnTheInternet",
 	"Actions": [
 		{

--- a/src/pi/actions/command.ts
+++ b/src/pi/actions/command.ts
@@ -67,7 +67,22 @@ class PiCommand implements PiAction {
             ));
         }
 
-        const id = commandSelect.find("option:selected").val() as string;
+        const settingsId = this.settings.action.id;
+
+        const systemId = systemCommandOptGroup.find("option:selected").val() as string;
+        const customId = customCommandOptGroup.find("option:selected").val() as string;
+
+        let id: string;
+
+        if (systemId === settingsId) {
+            id = systemId;
+        } else if (customId === settingsId) {
+            id = customId;
+        }
+
+        if (id == null) {
+            id = commands[0].id;
+        }
 
         if (id !== this.settings.action.id) {
             this.settings.action.id = id;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes an issue where the run command action would reset its command to an invalid state every time the action was selected (the settings window/property inspector was opened)

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
fix #5

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the selected command no longer resets when opening the settings window


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
